### PR TITLE
feat: support encryption on first boot

### DIFF
--- a/classes/mender-luks-part-images.bbclass
+++ b/classes/mender-luks-part-images.bbclass
@@ -12,33 +12,3 @@ IMAGE_CMD:bootimg:append() {
   fi
 }
 
-IMAGE_CMD:biosimg:append() {
-  do_mender_luks_encrypt_image "biosimg"
-}
-IMAGE_CMD:gptimg:append() {
-  do_mender_luks_encrypt_image "gptimg"
-}
-IMAGE_CMD:sdimg:append() {
-  do_mender_luks_encrypt_image "sdimg"
-}
-IMAGE_CMD:uefiimg:append() {
-  do_mender_luks_encrypt_image "uefiimg"
-}
-
-################################################################################
-do_mender_luks_encrypt_image() {
-  local suffix="$1"
-
-  bbwarn "\n!!! The created image IS NOT encrypted. That is left for you to (optionally) do post build."                \
-         "\n!!! That means this build/image is not yet suitable for device provisioning."                               \
-         "\n!!! The mender artifacts however are perfectly usable as-is, so no need to encrypt if that's all you need." \
-         "\n!!! To generate an encrypted image suitable for provisioning, run:"                                         \
-         "\n"                                                                                                           \
-         "\n      bitbake       mender-luks-encrypt-image-native -caddto_recipe_sysroot       && \ "                    \
-         "\n      oe-run-native mender-luks-encrypt-image-native mender-luks-encrypt-image.sh    \ "                    \
-         "\n        ${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.${suffix}"                                                        \
-         "\n"                                                                                                           \
-         "\n!!! Note that this will likely take a long time to complete. Aborting this script before completion may"    \
-         "\n!!! require manual cleanup. See docs for more info."                                                        \
-         "\n"
-}

--- a/classes/mender-luks-vars.bbclass
+++ b/classes/mender-luks-vars.bbclass
@@ -46,7 +46,7 @@ MENDER/LUKS_CRYPTSETUP_KEY_SIZE   ??= "512"
 MENDER/LUKS_CRYPTSETUP_CIPHER     ??= "aes-xts-plain64"
 MENDER/LUKS_CRYPTSETUP_HASH       ??= "sha512"
 MENDER/LUKS_CRYPTSETUP_PBKDF      ??= "argon2i"
-MENDER/LUKS_CRYPTSETUP_OPTS_BASE    = "--type luks2 --batch-mode"
+MENDER/LUKS_CRYPTSETUP_OPTS_BASE    = "--type luks2"
 MENDER/LUKS_CRYPTSETUP_OPTS_SPECS   = "                                                \
                                                    ${MENDER/LUKS_CRYPTSETUP_OPTS_BASE} \
                                         --key-size ${MENDER/LUKS_CRYPTSETUP_KEY_SIZE}  \


### PR DESCRIPTION
I have copied/modified mender_luks_encrypt_part in mender-luks-init.sh.

If you recommend so, I could attempt to make this function part of mender-luks-util.sh and attempt to make the same logic used in mender-luks-encrypt-image.sh. But personally I would argue against it in this case, and would prefer copying the code as it is small and on boot we are very restricted so there is meaningful difference now (and perhaps more for future changes).

If you also want to, I could later make another PR to change mender-luks-encrypt-image.sh to be interruptible and repeatable same as with the boot, which would fix [15](https://github.com/coreycothrum/meta-mender-luks/issues/15) 